### PR TITLE
Change to ensure duplicate labels are not added to page

### DIFF
--- a/nvsvocprez/app.py
+++ b/nvsvocprez/app.py
@@ -1679,7 +1679,9 @@ class ConceptRenderer(Renderer):
             elif p == str(SKOS.prefLabel):
                 context["prefLabel"] = o
             elif p == str(SKOS.altLabel):
-                context["altLabels"].append(o)
+                if o not in context["altLabels"]:
+                    context["altLabels"].append(o)
+
             elif p == str(SKOS.definition):
                 context["definition"] = o
             elif p == str(DCTERMS.date):


### PR DESCRIPTION
Labels are being added to a dictionary which are then presented on the webpage.

The code does a simple check to ensure that the label is not already in the dictionary before adding it.